### PR TITLE
chore: Enforce conventional commits on PR titles

### DIFF
--- a/.github/workflows/ValidatePRTitle.yml
+++ b/.github/workflows/ValidatePRTitle.yml
@@ -1,0 +1,51 @@
+# NOTE
+# Our base CI system is CircleCI, but for anything that interacts with the PR metadata works better in GHA so we use GHA
+# here.
+
+name: "Validate PR Title"
+description: "Enforces the PR title follows conventional commits."
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+
+permissions:
+  pull-requests: write
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            chore
+            refactor
+            fix
+            feat
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+
+            Details:
+
+            ${{ steps.lint_pr_title.outputs.error_message }}
+
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          delete: true


### PR DESCRIPTION
We rely heavily on conventional commits to generate release notes and manage versioning. Requiring conventional commits on every commit can be heavy handed though so we only enforce it on the PR, and use squash merge to enforce it on `main` and the `release` branch.